### PR TITLE
Fix some erratas and add missing items

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,6 +1176,11 @@
               <li data-id="weapons_3_22"><a href="https://eldenring.wiki.fextralife.com/Arbalest">Arbalest</a></li>
               <li data-id="weapons_3_23"><a href="https://eldenring.wiki.fextralife.com/Crepus's+Black-Key+Crossbow">Crepus's Black-Key Crossbow</a></li>
             </ul>
+            <h4><a href="https://eldenring.wiki.fextralife.com/Crossbows">Ballistas</a></h4>
+            <ul>
+              <li data-id="weapons_3_24"><a href="https://eldenring.wiki.fextralife.com/Hand+Ballista">Hand Ballista</a></li>
+              <li data-id="weapons_3_25"><a href="https://eldenring.wiki.fextralife.com/Jar+Cannon">Jar Cannon</a></li>
+            </ul>
           </div>
 
           <h3 id="Catalysts"><a href="#Catalysts_col" data-toggle="collapse" class="btn btn-primary btn-collapse btn-sm"></a><a href="https://eldenring.wiki.fextralife.com/Weapons">Catalysts</a> <span id="weapons_totals_4"></span></h3>
@@ -1189,11 +1194,11 @@
               <li data-id="weapons_4_14"><a href="https://eldenring.wiki.fextralife.com/Carian+Regal+Scepter">Carian Regal Scepter</a></li>
               <li data-id="weapons_4_15"><a href="https://eldenring.wiki.fextralife.com/Digger's+Staff">Digger's Staff</a></li>
               <li data-id="weapons_4_16"><a href="https://eldenring.wiki.fextralife.com/Astrologer's+Staff">Astrologer's Staff</a></li>
-              <li data-id="weapons_4_17"><a href="https://eldenring.wiki.fextralife.com/Carian+Glintblade+Staff">Carian Glintstone Staff</a></li>
+              <li data-id="weapons_4_17"><a href="https://eldenring.wiki.fextralife.com/Carian+Glintblade+Staff">Carian Glintblade Staff</a></li>
               <li data-id="weapons_4_18"><a href="https://eldenring.wiki.fextralife.com/Prince+of+Death's+Star">Prince of Death's Star</a></li>
               <li data-id="weapons_4_19"><a href="https://eldenring.wiki.fextralife.com/Albinauric+Staff">Ablibauric Staff</a></li>
               <li data-id="weapons_4_20"><a href="https://eldenring.wiki.fextralife.com/Academy+Glintstone+Staff">Academy Glintstone Staff</a></li>
-              <li data-id="weapons_4_21"><a href="https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff">Carian Glintstone</a></li>
+              <li data-id="weapons_4_21"><a href="https://eldenring.wiki.fextralife.com/Carian+Glintstone+Staff">Carian Glintstone Staff</a></li>
               <li data-id="weapons_4_22"><a href="https://eldenring.wiki.fextralife.com/Azur's+Glintstone+Staff">Azur's Glintstone Staff</a></li>
               <li data-id="weapons_4_23"><a href="https://eldenring.wiki.fextralife.com/Lusat's+Glintstone+Staff">Lusat's Glintstone Staff</a></li>
               <li data-id="weapons_4_24"><a href="https://eldenring.wiki.fextralife.com/Meteorite+Staff">Meteorite Staff</a></li>
@@ -1246,6 +1251,7 @@
               <li data-id="weapons_2_21"><a href="">Smoldering Shield</a></li>
               <li data-id="weapons_2_22"><a href="">Spiralhorn Shield</a></li>
               <li data-id="weapons_2_23"><a href="">Coil Shield</a></li>
+              <li data-id="weapons_2_37"><a href="https://eldenring.wiki.fextralife.com/Shield+of+the+Guilty">Shield of the Guilty</a></li>
             </ul>
             <h4><a href="https://eldenring.wiki.fextralife.com/Medium+Shields">Medium Shields</a></h4>
             <ul>
@@ -1262,7 +1268,6 @@
               <li data-id="weapons_2_34"><a href="">Blue-Gold Kite Shield</a></li>
               <li data-id="weapons_2_35"><a href="">Brass Shield</a></li>
               <li data-id="weapons_2_36"><a href="">Great Turtle Shield</a></li>
-              <li data-id="weapons_2_37"><a href="">Shield of the Guilty</a></li>
               <li data-id="weapons_2_38"><a href="">Carian Knight's Shield</a></li>
               <li data-id="weapons_2_39"><a href="">Large Leather Shield</a></li>
               <li data-id="weapons_2_40"><a href="">Horse Crest Wooden Shield</a></li>
@@ -1337,7 +1342,8 @@
             <li data-id="armors_5_7"><a href="">Viridian Amber Medallion</a></li>
             <li data-id="armors_5_8"><a href="">Viridian Amber Medallion +1</a></li>
             <li data-id="armors_5_9"><a href="">Viridian Amber Medallion +2</a></li>
-            <li data-id="armors_5_10"><a href="">Arsenal Charm</a></li>
+            <li data-id="armors_5_10"><a href="https://eldenring.wiki.fextralife.com/Arsenal+Charm">Arsenal Charm</a></li>
+            <li data-id="armors_5_10"><a href="https://eldenring.wiki.fextralife.com/Arsenal+Charm">Arsenal Charm +1</a></li>
             <li data-id="armors_5_11"><a href="">Great-Jar's Arsenal</a></li>
             <li data-id="armors_5_12"><a href="">Erdtree's Favor</a></li>
             <li data-id="armors_5_13"><a href="">Erdtree's Favor +1</a></li>


### PR DESCRIPTION
- Fix Carian Glintblade Staff to reflect its link accurately
- Correct item name for Carian Glintstone Staff
- Move 'Shield of the Guilty' from Medium Shield to Small Shield category
- Add missing talisman 'Arsenal Charm +1'
- Add new subcategory for Ranged Weapons - Ballistas and all relevant weapons